### PR TITLE
feat: split up the accessor, branch filtering

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -11,8 +11,9 @@ dependencies {
     testCompile 'org.apache.commons:commons-text:1.4'
     testCompile 'com.google.code.gson:gson:2.8.5'
     testCompile 'com.google.guava:guava:26.0-jre'
-    testCompile 'org.junit.jupiter:junit-jupiter-api:5.2.0'
-    testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.2.0'
+    testCompile 'org.junit.jupiter:junit-jupiter-api:5.3.1'
+    testCompile 'org.junit.jupiter:junit-jupiter-params:5.3.1'
+    testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
     jmh 'com.google.guava:guava:26.0-jre'
 }
 

--- a/agent/src/jmh/java/io/snyk/agent/logic/RewritePerformance.java
+++ b/agent/src/jmh/java/io/snyk/agent/logic/RewritePerformance.java
@@ -9,7 +9,6 @@ import org.openjdk.jmh.annotations.*;
 import java.util.concurrent.TimeUnit;
 
 // notes:
-//  * due to plugin bug, the code must be build against asm 5, and hence requires generics casts
 //  * due to plugin bug, gradle must be run with --no-daemon or it will randomly fail to rebuild the code
 //  * (it's still better than the jmh-by-hand situation)
 
@@ -40,13 +39,13 @@ public class RewritePerformance {
 
     @Benchmark
     public byte[] justRewrite() {
-        return new Rewriter(LandingZone.class, LandingZone.SEEN_SET::add, "13371337:tests", true)
+        return new Rewriter(LandingZone.class, LandingZone.SEEN_SET::add, "13371337:tests", false, false, false)
                 .rewrite(classReaderBlackHole);
     }
 
     @Benchmark
     public byte[] loadBoth() {
-        return new Rewriter(LandingZone.class, LandingZone.SEEN_SET::add, "13371337:tests", true)
+        return new Rewriter(LandingZone.class, LandingZone.SEEN_SET::add, "13371337:tests", false, false, false)
                 .rewrite(new ClassReader(classBlackHole));
     }
 

--- a/agent/src/main/java/io/snyk/agent/jvm/Transformer.java
+++ b/agent/src/main/java/io/snyk/agent/jvm/Transformer.java
@@ -87,7 +87,8 @@ class Transformer implements ClassFileTransformer {
             return null;
         }
 
-        return new Rewriter(LandingZone.class, LandingZone.SEEN_SET::add, info.toLocation(), config.trackClassLoading)
+        return new Rewriter(LandingZone.class, LandingZone.SEEN_SET::add, info.toLocation(), config.trackClassLoading, config.trackAccessors,
+                config.trackBranchingMethods)
                 .rewrite(reader);
     }
 

--- a/agent/src/main/java/io/snyk/agent/logic/InstrumentationFilter.java
+++ b/agent/src/main/java/io/snyk/agent/logic/InstrumentationFilter.java
@@ -84,8 +84,6 @@ public class InstrumentationFilter {
 
     /**
      * Try and eliminate some methods we don't want to look at.
-     * TODO: This is actually mandatory, as it enforces some asserts
-     * TODO: that the actual rewriter should be enforcing, perhaps?
      */
     static boolean skipMethod(ClassNode self, MethodNode method) {
         // `abstract` and `native` methods don't have Java code in them,
@@ -113,16 +111,7 @@ public class InstrumentationFilter {
         // Signatures which you'd think we could ignore, but probably can't:
         //  * `void foo()`: this is the internal type of constructors, maybe exclude those?
 
-//        Type.getArgumentTypes(method.desc);
-//        Type.getReturnType(method.desc);
-
-        if (isAccessor(method)) {
-            return true;
-        }
-
-        if (!branches(self, method)) {
-            return true;
-        }
+        // TODO: currently we are doing no signature filtering, beyond the <clinit thing
 
         return false;
     }
@@ -193,7 +182,7 @@ public class InstrumentationFilter {
         return false;
     }
 
-    private static boolean isAccessor(MethodNode method) {
+    static boolean isAccessor(MethodNode method) {
         if (isStatic(method.access)) {
             return false;
         }

--- a/agent/src/test/java/io/snyk/agent/logic/RewriterTest.java
+++ b/agent/src/test/java/io/snyk/agent/logic/RewriterTest.java
@@ -17,7 +17,8 @@ class RewriterTest {
     @Test
     void smokeTest() throws Exception {
         final String name = TestVictim.class.getName();
-        final byte[] bytes = new Rewriter(TestTracker.class, TestTracker.SEEN_SET::add, TEST_LOCATION, true)
+        final byte[] bytes = new Rewriter(TestTracker.class, TestTracker.SEEN_SET::add, TEST_LOCATION, true,
+                false, false)
                 .rewrite(new ClassReader(name));
         final Class<?> clazz = new DefinerLoader().define(name, bytes);
         final Object instance = clazz.newInstance();

--- a/common/src/main/java/io/snyk/agent/logic/ConfigBuilder.java
+++ b/common/src/main/java/io/snyk/agent/logic/ConfigBuilder.java
@@ -1,0 +1,21 @@
+package io.snyk.agent.logic;
+
+import io.snyk.agent.filter.Filter;
+
+import java.util.List;
+
+class ConfigBuilder {
+    String projectId;
+    List<Filter> filters;
+    String urlPrefix;
+    boolean trackClassLoading;
+    boolean trackAccessors;
+    boolean trackBranchingMethods;
+    boolean debugLoggingEnabled;
+
+    Config build() {
+        return new Config(projectId, filters, urlPrefix, trackClassLoading,
+                trackAccessors,
+                trackBranchingMethods, debugLoggingEnabled);
+    }
+}


### PR DESCRIPTION
Allow separate configuration of `isAccessor` and `branches` filtering.
Verbose but irrelevant changes to config parser rolled in.
