### PR TITLE
feat: end-to-end test for goof in docker

### DIFF
--- a/agent/e2e/.dockerignore
+++ b/agent/e2e/.dockerignore
@@ -1,0 +1,2 @@
+Makefile
+.gitignore

--- a/agent/e2e/.gitignore
+++ b/agent/e2e/.gitignore
@@ -1,0 +1,1 @@
+snyk-agent.jar

--- a/agent/e2e/Dockerfile
+++ b/agent/e2e/Dockerfile
@@ -1,0 +1,17 @@
+FROM buildpack-deps:18.04-scm
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+        apt-get update && \
+        apt-get install -y openjdk-8-jdk-headless openjdk-11-jre-headless- maven netcat-openbsd jq python3 && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists
+
+WORKDIR /root
+
+RUN git clone https://github.com/snyk/java-goof && \
+        cd java-goof && \
+        mvn package tomcat7:help
+
+COPY snyk-agent.jar snyk-goof-e2e.properties test-script.sh simple_homebase.py /root/
+
+ENTRYPOINT bash test-script.sh

--- a/agent/e2e/Makefile
+++ b/agent/e2e/Makefile
@@ -1,0 +1,7 @@
+all: build-verbose
+	(cd ../.. && ./gradlew shadow)
+	cp ../build/libs/agent.jar snyk-agent.jar
+	docker run -i $(shell docker build -q .)
+
+build-verbose:
+	docker build .

--- a/agent/e2e/simple_homebase.py
+++ b/agent/e2e/simple_homebase.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        with open('{}.json'.format(i), 'w') as f:
+            f.write(self.rfile.read(int(self.headers['Content-Length'])).decode('utf-8'))
+        self.rfile.close()
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b'{"status":"ok"}')
+
+
+for i in range(int(sys.argv[1])):
+    HTTPServer(('0.0.0.0', 1337), Handler).handle_request()

--- a/agent/e2e/snyk-goof-e2e.properties
+++ b/agent/e2e/snyk-goof-e2e.properties
@@ -1,0 +1,8 @@
+projectId=0153525f-5a99-4efe-a84f-454f12494033
+homeBaseUrl=http://localhost:1337/foo
+
+filter.jakarta-multipart.artifact = maven:org.apache.struts:struts2-core
+filter.jakarta-multipart.paths = org/apache/struts2/dispatcher/multipart/JakartaMultiPartRequest#buildErrorMessage
+
+filter.req-happening.artifact = maven:org.apache.struts:struts2-core
+filter.req-happening.paths = org/apache/struts2/dispatcher/Dispatcher#serviceAction

--- a/agent/e2e/test-script.sh
+++ b/agent/e2e/test-script.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -eux
+
+# PWD: /root
+# goof: /root/java-goof
+
+# run our "homebase" in the background
+python3 simple_homebase.py 10 &
+HOMEBASE_PID=$!
+
+# start the app
+(
+  cd java-goof &&
+  MAVEN_OPTS="-javaagent:/root/snyk-agent.jar=file:///root/snyk-goof-e2e.properties" \
+    mvn tomcat7:run
+) &
+
+TOMCAT_PID=$!
+
+trap "kill ${TOMCAT_PID} ${HOMEBASE_PID}" EXIT
+
+# wait for the app to start
+for i in 1 2 3 4 5; do
+    sleep 1
+    # we don't really care if this fails for another reason, we'll try it again later
+    curl -q http://localhost:8080 && break
+done
+
+# start printing the agent logs
+(tail -n5000 -f java-goof/snyk-agent-*.log | sed 's/^/snyk-agent.log: /') &disown
+
+# exploit the app
+<java-goof/exploits/struts-exploit-headers.txt sed "s/COMMAND/env/" | xargs curl -v -X GET http://localhost:8080 -H
+
+# wait for the next report from the agent
+sleep 6
+
+# show the reports
+jq --color-output . *.json
+
+# we must have hit the methodEntry
+fgrep org/apache/struts2/dispatcher/multipart/JakartaMultiPartRequest *.json >/dev/null || (
+    echo Class was never mentioned...
+    exit 4
+)

--- a/agent/src/main/java/io/snyk/agent/logic/ReportingWorker.java
+++ b/agent/src/main/java/io/snyk/agent/logic/ReportingWorker.java
@@ -124,7 +124,7 @@ public class ReportingWorker implements Runnable {
         Json.appendString(msg, vmVendor);
         msg.append(",\"version\":");
         Json.appendString(msg, vmVersion);
-        msg.append(",\"correlationId\":");
+        msg.append("}},\"correlationId\":");
         Json.appendString(msg, UUID.randomUUID().toString());
         msg.append(",");
         return msg;


### PR DESCRIPTION
- [x] Tests written [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Run `make`, and it'll build the agent locally, set-up `java-goof` in docker, exploit it, and check we reported the exploit to a (fake) homebase.

### Notes for the reviewer

It doesn't really print anything useful if everything's going to plan. It prints a whole load of errors, 'cos tomcat's (exploited) logs are intermingled with everything.

It might have been better not as a shell script. I have some regrets.