### PR TITLE
feat: load config from near the jar, write logs near the config

### DIFF
--- a/agent/.gitignore
+++ b/agent/.gitignore
@@ -1,3 +1,4 @@
 /build/
 /out/
 snyk-agent-*.log
+/snyk-logs/

--- a/agent/e2e/test-script.sh
+++ b/agent/e2e/test-script.sh
@@ -26,7 +26,7 @@ rm -f java-goof/snyk-agent-*.log
 
 TOMCAT_PID=$!
 
-trap "kill ${TOMCAT_PID} && rm ${TEMP_DIR}/*.json ${TEMP_DIR}/*.properties && rmdir ${TEMP_DIR}" EXIT
+trap "kill ${TOMCAT_PID} && rm -r '${TEMP_DIR}'" EXIT
 
 # wait for the app to start
 for i in {1..30}; do
@@ -44,7 +44,7 @@ done
 sleep 6
 
 # show the reports
-tail -n5000 java-goof/snyk-agent-*.log
+tail -n5000 ${TEMP_DIR}/snyk-logs/agent-*.log
 jq --color-output . ${TEMP_DIR}/*.json
 
 # we must have hit the methodEntry

--- a/agent/src/main/java/io/snyk/agent/jvm/ConfigSearch.java
+++ b/agent/src/main/java/io/snyk/agent/jvm/ConfigSearch.java
@@ -1,0 +1,97 @@
+package io.snyk.agent.jvm;
+
+import io.snyk.agent.util.Log;
+
+import java.io.File;
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
+import java.util.ArrayList;
+import java.util.List;
+
+class ConfigSearch {
+
+    private static final String AGENT_PROPS = "snyk-agent.properties";
+
+    static File find(String agentArguments) {
+        final String provided;
+        if (null != agentArguments && !agentArguments.isEmpty()) {
+            if (!agentArguments.startsWith("file:")) {
+                Log.loading("invalid arguments, expected file:, not " + agentArguments);
+                return null;
+            }
+
+            provided = agentArguments.substring("file:".length());
+
+            final File candidate = new File(provided);
+            if (candidate.isAbsolute()) {
+                return candidate;
+            }
+        } else {
+            provided = AGENT_PROPS;
+        }
+
+        Log.loading("resolving \"" + provided + "\" to an absolute path");
+
+        for (File searchPath : searchIn()) {
+            final File candidate = new File(searchPath, provided);
+            Log.loading("trying: " + candidate.getAbsolutePath());
+            if (candidate.isFile()) {
+                return candidate;
+            }
+        }
+
+        Log.loading("failed: file could not be found, please specify a valid absolute path");
+        return null;
+    }
+
+    /**
+     * A list of places we might find the config file, if the user didn't specify an absolute path on the command line.
+     */
+    private static List<File> searchIn() {
+        final List<File> locations = new ArrayList<>();
+        final File ourSourceLocation = ourSourceLocation();
+        if (null != ourSourceLocation) {
+            locations.add(ourSourceLocation);
+        }
+
+        // so.. current directory? Not going to make sense to most people.
+
+        // Just one then.
+
+        return locations;
+    }
+
+    /**
+     * Try and resolve the path of the agent jar, using a simpler (less reliable) method than the main agent code uses.
+     *
+     * We could use the same code? We're just trying to help here.
+     */
+    private static File ourSourceLocation() {
+        final ProtectionDomain pd;
+
+        try {
+            pd = ConfigSearch.class.getProtectionDomain();
+        } catch (SecurityException ignored) {
+            return null;
+        }
+
+        final CodeSource source = pd.getCodeSource();
+
+        if (null == source) {
+            return null;
+        }
+
+        final URL location = source.getLocation();
+
+        if (null == location) {
+            return null;
+        }
+
+        if (!"file".equals(location.getProtocol())) {
+            return null;
+        }
+
+        return new File(location.getPath()).getParentFile();
+    }
+}

--- a/agent/src/main/java/io/snyk/agent/jvm/EntryPoint.java
+++ b/agent/src/main/java/io/snyk/agent/jvm/EntryPoint.java
@@ -5,6 +5,7 @@ import io.snyk.agent.logic.Config;
 import io.snyk.agent.logic.ReportingWorker;
 import io.snyk.agent.util.Log;
 
+import java.io.File;
 import java.lang.instrument.Instrumentation;
 import java.lang.instrument.UnmodifiableClassException;
 import java.net.MalformedURLException;
@@ -18,13 +19,15 @@ class EntryPoint {
             Instrumentation instrumentation) throws MalformedURLException {
         Log.loading("startup");
 
-        if (null == agentArguments || !agentArguments.startsWith("file:")) {
-            throw new IllegalStateException("expected file:[path to config file]");
+        final File configFile = ConfigSearch.find(agentArguments);
+
+        if (null == configFile) {
+            throw new IllegalStateException("config file not found");
         }
 
-        final Config config = Config.fromFile(agentArguments.substring("file:".length()));
+        final Config config = Config.fromFile(configFile.getAbsolutePath());
 
-        final Log log = new Log(config.debugLoggingEnabled);
+        final Log log = new Log(configFile.getParentFile(), config.debugLoggingEnabled);
 
         log.info("loading config complete, projectId:" + config.projectId);
 

--- a/common/src/main/java/io/snyk/agent/util/Log.java
+++ b/common/src/main/java/io/snyk/agent/util/Log.java
@@ -1,9 +1,6 @@
 package io.snyk.agent.util;
 
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -33,20 +30,26 @@ public class Log {
     }
 
     public Log() {
-        this(false);
+        this(new File("."), false);
     }
 
-    public Log(boolean debugEnabled) {
+    public Log(File baseDir, boolean debugEnabled) {
         this.debugEnabled = debugEnabled;
 
-        Log.loading("switching to main logging...");
+        final File logDir = new File(baseDir, "snyk-logs");
+        if (!logDir.isDirectory() && !logDir.mkdirs()) {
+            throw new IllegalStateException("invalid log dir: " + logDir);
+        }
+
+        final File logPath = new File(logDir,
+                "agent-" + new SimpleDateFormat("yyyy-MM-dd'T'HH-mm-ss.SSS'Z'", Locale.US).format(new Date()) + ".log");
+
+        Log.loading("switching logging to " + logPath.getAbsolutePath());
 
         try {
-            logFile = new PrintWriter(new OutputStreamWriter(new FileOutputStream("snyk-agent-" +
-                    new SimpleDateFormat("yyyy-MM-dd'T'HH-mm-ss.SSS'Z'", Locale.US).format(new Date())
-                    + ".log"), StandardCharsets.UTF_8));
+            logFile = new PrintWriter(new OutputStreamWriter(new FileOutputStream(logPath),
+                    StandardCharsets.UTF_8));
 
-            // note: must be last
             synchronized (Log.class) {
                 instance = this;
 


### PR DESCRIPTION
### What this does

Previously, the agent would take an absolute path to the config file as an argument, and write logs to the current directory.

Now, the configuration file can be missing (and a file named `snyk-agent.properties` will be searched for), or a relative path. It will be resolved relative to the `agent.jar` if possible.

The logs are written in a folder next to the config file.

This will help people be able to actually find the logs, and reduces the complexity of specifying a config file.

### Notes for the reviewer

Not super sold on the `ProtectionDomain` method of finding the source. If it goes wrong, we just fall-back to the old behaviour (for finding the config file), but still have the win on the `logs`. It is written to not fail/warn, just to silently fallback to the old behaviour.

### Screenshots

```
% java -javaagent:agent/build/libs/agent.jar -cp simplest-test/build/libs/simplest-test.jar io.snyk.demo.Main

2018-10-09T10:59:01.233Z snyk-agent initialisation: startup
2018-10-09T10:59:01.282Z snyk-agent initialisation: resolving "snyk-agent.properties" to an absolute path
2018-10-09T10:59:01.282Z snyk-agent initialisation: trying: /home/faux/code/java-instrumentor/agent/build/libs/snyk-agent.properties
2018-10-09T10:59:01.283Z snyk-agent initialisation: loading config from: /home/faux/code/java-instrumentor/agent/build/libs/snyk-agent.properties
2018-10-09T10:59:01.310Z snyk-agent initialisation: switching logging to /home/faux/code/java-instrumentor/agent/build/libs/snyk-logs/agent-2018-10-09T11-59-01.310Z.log
```

(..and no further logging is written to stdout)
