### PR TITLE
feat: accept version range expressions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,9 +63,7 @@ task methodsToProperties() << {
 
         filters += "filter.provided-${i}.paths = ${fullClassName}#${method.methodName}\n"
         filters += "filter.provided-${i}.artifact = maven:${record.packageName}\n"
-        if (false) {
-            filters += "filter.provided-${i}.version = ${versions}\n"
-        }
+        filters += "filter.provided-${i}.version = ${versions}\n"
         filters += "\n"
     }
 

--- a/src/main/java/io/snyk/agent/filter/VersionFilter.java
+++ b/src/main/java/io/snyk/agent/filter/VersionFilter.java
@@ -2,52 +2,84 @@ package io.snyk.agent.filter;
 
 import io.snyk.agent.util.org.apache.maven.artifact.versioning.ComparableVersion;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
- * Stub implementation: only supports <, > or = a version.
- *
  * Note that versions are compared using the Maven version syntax, not semver,
  * so versions with hyphens and letters (and all kinds of other horrors) in will work.
  */
 public class VersionFilter implements Predicate<String> {
 
-    public final ComparableVersion version;
-    public final int direction;
+    // anything except comma, ], ), and space; our delimiters.
+    private static final String VERSION_PART_REGEX = "([^,\\])\\s]*)";
 
-    private VersionFilter(ComparableVersion version, int direction) {
-        this.version = version;
-        this.direction = direction;
+    // e.g. [3,)
+    // e.g. (3,5]
+    // e.g. (,7)
+    private static final Pattern VERSION_EXPRESSION = Pattern.compile(
+            "([\\[(])" + // [ or (
+                    VERSION_PART_REGEX + // the first version bit
+                    "\\s*,\\s*" + // comma
+                    VERSION_PART_REGEX + // the second version bit
+                    "([\\])])" // ] or )
+    );
+
+    private final List<Predicate<ComparableVersion>> options;
+
+    private VersionFilter(List<Predicate<ComparableVersion>> options) {
+        this.options = options;
     }
 
     public static VersionFilter parse(String expression) {
-        if (expression.length() < 2) {
-            throw new IllegalStateException("too short: " + expression);
+        final List<Predicate<ComparableVersion>> options = new ArrayList<>();
+
+        for (String part :  expression.split("\\s+")) {
+            final Matcher ma = VERSION_EXPRESSION.matcher(part);
+            if (!ma.matches()) {
+                throw new IllegalStateException("invalid version expression: " + part);
+            }
+
+            final boolean startClosed = ma.group(1).equals("[");
+            final String startExpr = ma.group(2);
+            final String endExpr = ma.group(3);
+            final boolean endClosed = ma.group(4).equals("]");
+
+            final Optional<ComparableVersion> startVersion = versionOrEmpty(startExpr);
+            final Optional<ComparableVersion> endVersion = versionOrEmpty(endExpr);
+
+            options.add(candidate ->
+                    startVersion.map(version -> greaterThan(startClosed, candidate, version)).orElse(true) &&
+                            endVersion.map(version -> greaterThan(endClosed, version, candidate)).orElse(true));
         }
 
-        final int direction;
+        return new VersionFilter(options);
+    }
 
-        switch (expression.charAt(0)) {
-            case '<':
-                direction = -1;
-                break;
-            case '>':
-                direction = 1;
-                break;
-            case '=':
-                direction = 0;
-                break;
-            default:
-                throw new IllegalStateException("version expression must start with </>/=");
+    private static boolean greaterThan(boolean orEqualTo, ComparableVersion left, ComparableVersion right) {
+        final int comparison = left.compareTo(right);
+        if (orEqualTo) {
+            return comparison >= 0;
+        } else {
+            return comparison > 0;
+        }
+    }
+
+    private static Optional<ComparableVersion> versionOrEmpty(String expr) {
+        if (expr.isEmpty()) {
+            return Optional.empty();
         }
 
-        final ComparableVersion version = new ComparableVersion(expression.substring(1).trim());
-
-        return new VersionFilter(version, direction);
+        return Optional.of(new ComparableVersion(expr));
     }
 
     @Override
-    public boolean test(String s) {
-        return direction == new ComparableVersion(s).compareTo(version);
+    public boolean test(String version) {
+        final ComparableVersion comparableVersion = new ComparableVersion(version);
+        return options.stream().anyMatch(p -> p.test(comparableVersion));
     }
 }

--- a/src/main/java/io/snyk/agent/logic/ReportingWorker.java
+++ b/src/main/java/io/snyk/agent/logic/ReportingWorker.java
@@ -207,14 +207,6 @@ public class ReportingWorker implements Runnable {
                 msg.append(",\"artifact\":");
                 Json.appendString(msg, artifact);
             });
-            filter.version.ifPresent(version -> {
-                msg.append(",\"version\":");
-                Json.appendString(msg, version.version.toString());
-
-                // TODO: this isn't great, in future this will allow other things...
-                msg.append(",\"versionDirection\":");
-                msg.append(version.direction);
-            });
             msg.append(",\"paths\":[");
             filter.pathFilters.forEach(pathFilter -> {
                 msg.append("{\"className\":");

--- a/src/test/java/io/snyk/agent/filter/FilterTest.java
+++ b/src/test/java/io/snyk/agent/filter/FilterTest.java
@@ -31,7 +31,7 @@ class FilterTest {
     void testVersionLessThan() {
         final Filter filter = new Filter("foo",
                 Optional.of("maven:io.snyk:snyk-agent"),
-                Optional.of(VersionFilter.parse("<3")),
+                Optional.of(VersionFilter.parse("[,3)")),
                 Collections.emptyList());
 
         assertTrue(filter.testArtifacts(new TestLogger(), Collections.emptyList()),

--- a/src/test/java/io/snyk/agent/filter/VersionFilterTest.java
+++ b/src/test/java/io/snyk/agent/filter/VersionFilterTest.java
@@ -8,8 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class VersionFilterTest {
 
     @Test
-    void testMatching() {
-        final VersionFilter underThree = VersionFilter.parse("<3");
+    void testThree() {
+        final VersionFilter underThree = VersionFilter.parse("[,3)");
         assertTrue(underThree.test("1"));
         assertTrue(underThree.test("2"));
         assertFalse(underThree.test("3"));
@@ -17,5 +17,25 @@ class VersionFilterTest {
 
         assertTrue(underThree.test("2.5"));
         assertFalse(underThree.test("3.5"));
+    }
+
+    @Test
+    void testThreeOpen() {
+        final VersionFilter underThree = VersionFilter.parse("[,3]");
+        assertTrue(underThree.test("2"));
+        assertTrue(underThree.test("3"));
+        assertFalse(underThree.test("4"));
+    }
+
+    @Test
+    void testMultiple() {
+        final VersionFilter underThree = VersionFilter.parse("[1,2) [4,5)");
+        assertTrue(underThree.test("1"));
+        assertTrue(underThree.test("1.5"));
+        assertFalse(underThree.test("2"));
+        assertFalse(underThree.test("3"));
+        assertTrue(underThree.test("4"));
+        assertTrue(underThree.test("4.5"));
+        assertFalse(underThree.test("5"));
     }
 }

--- a/src/test/java/io/snyk/agent/jvm/TransformerTest.java
+++ b/src/test/java/io/snyk/agent/jvm/TransformerTest.java
@@ -53,13 +53,13 @@ class TransformerTest {
 
         assertFalse(exampleChanges("Foo",
                 "filter.foo.artifact = maven:io.snyk.example:example",
-                "filter.foo.version = <1.2.0",
+                "filter.foo.version = [,1.2.0)",
                 "filter.foo.paths = io/snyk/**"),
                 "We know where the io.snyk classes are from, they're newer than stated");
 
         assertTrue(exampleChanges("Foo",
                 "filter.foo.artifact = maven:io.snyk.example:example",
-                "filter.foo.version = <1.3.0",
+                "filter.foo.version = [,1.3.0)",
                 "filter.foo.paths = io/snyk/**"),
                 "We know where the io.snyk classes are from, they're older than stated");
     }

--- a/src/test/java/io/snyk/agent/logic/ReportingWorkerTest.java
+++ b/src/test/java/io/snyk/agent/logic/ReportingWorkerTest.java
@@ -148,7 +148,7 @@ class ReportingWorkerTest {
         onlyConfig(Arrays.asList(
                 "filter.foo.paths = foo/**",
                 "filter.bar.paths = bar/**#baz",
-                "filter.bar.version = <1.3.3",
+                "filter.bar.version = [,1.3.3)",
                 "filter.bar.artifact = maven:foo:bar"
         ));
     }


### PR DESCRIPTION
- [x] Tests written [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Accept and filter using the version ranges, as currently in `methods.json`.

### Notes for the reviewer

Using a regex-based parser as there doesn't really seem to be a popular library that does what we want, even for similar syntaxes (e.g. `[a..b)`).

I've taken the "version" config reporting out of `ReportingWorker`. It's hard to produce. It wasn't useful before, nothing is consuming the information, and nothing wants to consume the information. If we're expecting people to use mostly built-in filters, it is very unlikely to ever be useful.

All of the test updates are just moving the old syntax to new syntax (`<3` -> `[,3)`). See `VersionFilterTest`.

### More information

- [Jira ticket SC-6462](https://snyksec.atlassian.net/browse/SC-6462)
