### PR TITLE
feat: configure heartbeat and beacon time

### DIFF
--- a/docs/example-beacon-heartbeat.json
+++ b/docs/example-beacon-heartbeat.json
@@ -1,0 +1,15 @@
+{
+  "projectId": "0153525f-5a99-4efe-a84f-454f12494033",
+  "timestamp": "2018-10-16T13:57:40.640023Z",
+  "systemInfo": {
+    "hostName": "anoia.goeswhere.com",
+    "jvm": {
+      "vmName": "30591@anoia.goeswhere.com",
+      "vendor": "Oracle Corporation",
+      "version": "10.0.2+13-Ubuntu-1ubuntu0.18.04.2"
+    }
+  },
+  "correlationId": "6abfba42-7444-43c2-b1bc-4ee67f97024b",
+  "runtimeAgentId": "375f06f4-114b-41a3-8c32-3b475438a5a9",
+  "heartbeat": true
+}

--- a/e2e/snyk-goof-e2e.properties
+++ b/e2e/snyk-goof-e2e.properties
@@ -1,5 +1,8 @@
 projectId=0153525f-5a99-4efe-a84f-454f12494033
 homeBaseUrl=file://OUTPUT_PATH
 
+heartBeatIntervalMs=1000
+reportIntervalMs=4000
+
 filter.req-happening.artifact = maven:org.apache.struts:struts2-core
 filter.req-happening.paths = org/apache/struts2/dispatcher/Dispatcher#serviceAction

--- a/src/main/java/io/snyk/agent/logic/Config.java
+++ b/src/main/java/io/snyk/agent/logic/Config.java
@@ -24,6 +24,9 @@ public class Config {
     public final List<Filter> filters;
     public final URI homeBaseUrl;
     public final long homeBasePostLimit;
+    public final long startupDelayMs;
+    public final long heartBeatIntervalMs;
+    public final long reportIntervalMs;
     public final boolean trackClassLoading;
     public final boolean debugLoggingEnabled;
     public final boolean trackBranchingMethods;
@@ -36,6 +39,9 @@ public class Config {
            List<Filter> filters,
            String homeBaseUrl,
            Long homeBasePostLimit,
+           long startupDelayMs,
+           long heartBeatIntervalMs,
+           long reportIntervalMs,
            boolean trackClassLoading,
            boolean trackAccessors,
            boolean trackBranchingMethods,
@@ -52,6 +58,9 @@ public class Config {
         } else {
             this.homeBasePostLimit = homeBasePostLimit;
         }
+        this.startupDelayMs = startupDelayMs;
+        this.heartBeatIntervalMs = heartBeatIntervalMs;
+        this.reportIntervalMs = reportIntervalMs;
         this.trackClassLoading = trackClassLoading;
         this.trackAccessors = trackAccessors;
         this.debugLoggingEnabled = debugLoggingEnabled;
@@ -147,6 +156,20 @@ public class Config {
 
             if ("skipBuiltInRules".equals(key)) {
                 builder.skipBuiltInRules = Boolean.parseBoolean(value);
+            }
+
+            if ("startupDelayMs".equals(key)) {
+                builder.startupDelayMs = Long.parseLong(value);
+                continue;
+            }
+
+            if ("heartBeatIntervalMs".equals(key)) {
+                builder.heartBeatIntervalMs = Long.parseLong(value);
+                continue;
+            }
+
+            if ("reportIntervalMs".equals(key)) {
+                builder.reportIntervalMs = Long.parseLong(value);
                 continue;
             }
 

--- a/src/main/java/io/snyk/agent/logic/ConfigBuilder.java
+++ b/src/main/java/io/snyk/agent/logic/ConfigBuilder.java
@@ -13,6 +13,9 @@ class ConfigBuilder {
     List<Filter> filters;
     String homeBaseUrl;
     Long homeBasePostLimit;
+    long startupDelayMs = 1_000;
+    long heartBeatIntervalMs = 30_000;
+    long reportIntervalMs = 60_000;
     boolean trackClassLoading;
     boolean trackAccessors;
     boolean trackBranchingMethods;
@@ -21,6 +24,7 @@ class ConfigBuilder {
 
     Config build() throws MalformedURLException {
         return new Config(projectId, filters, homeBaseUrl, homeBasePostLimit,
+                startupDelayMs, heartBeatIntervalMs, reportIntervalMs,
                 trackClassLoading, trackAccessors, trackBranchingMethods,
                 debugLoggingEnabled,
                 skipBuiltInRules);


### PR DESCRIPTION
- [x] Tests written [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Sends nearly-empty beacons more frequently than it would send events. The frequencies are configurable. The e2e test uses the configuration so it can work.

### Notes for the reviewer

The `if` inside `doPosting` decides whether we're going to early exit, or continue and do a full post.
