### PR TITLE
chore: re-enabled jdk9, and filter deployment to 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 jdk:
   - oraclejdk8
-#  - oraclejdk9
+  - oraclejdk9
 script:
 - ./gradlew build test distZip
 - git clone --depth 1 --branch java9 https://github.com/snyk/java-goof
@@ -23,6 +23,7 @@ cache:
 deploy:
   on:
     branch: master
+    jdk: oraclejdk8
   provider: s3
   access_key_id: $AWS_ACCESS_KEY_ID
   secret_access_key: $AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
### What this does

Ask the deployment to only run on jdk8, so we can re-enable tests on jdk9.

https://docs.travis-ci.com/user/deployment/#conditional-releases-with-on

> When all conditions specified in the on: section are met, your build will deploy.

> `jdk, node, perl, php, python, ruby, scala, go`: for language runtimes that support multiple versions, you can limit the deployment to happen only on the job that matches a specific version.