### PR TITLE
Ask Travis to test Java11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: java
 jdk:
-  - oraclejdk8
-  - oraclejdk9
+- oraclejdk8
+- oraclejdk11
+- openjdk11
 script:
 - ./gradlew build test distZip
 - git clone --depth 1 --branch java9 https://github.com/snyk/java-goof


### PR DESCRIPTION
### What this does

Remove testing on Java9, add testing on Java11 (both variants).

Java11 (like Java8) is a proper release, so will stick around for more than three months (we hope!), and might even get some adoption.

### Notes for the reviewer

This is atop the "fix" PR.

I (accidentally) changed the whitespace on the oraclejdk8 line (to be consistent with the rest of the file), it hasn't actually changed.

