### PR TITLE
feat: config option to log to stderr/nowhere

### DIFF
--- a/e2e/snyk-goof-e2e.properties
+++ b/e2e/snyk-goof-e2e.properties
@@ -1,5 +1,6 @@
 projectId=0153525f-5a99-4efe-a84f-454f12494033
 homeBaseUrl=file://OUTPUT_PATH
+logTo=stderr
 
 heartBeatIntervalMs=1000
 reportIntervalMs=4000

--- a/e2e/test-script.sh
+++ b/e2e/test-script.sh
@@ -44,7 +44,6 @@ done
 sleep 6
 
 # show the reports
-cat ${TEMP_DIR}/snyk-logs/agent-*.log
 jq --color-output . ${TEMP_DIR}/*.json
 
 # we must have hit the methodEntry

--- a/src/main/java/io/snyk/agent/jvm/EntryPoint.java
+++ b/src/main/java/io/snyk/agent/jvm/EntryPoint.java
@@ -3,9 +3,7 @@ package io.snyk.agent.jvm;
 import io.snyk.agent.logic.Config;
 import io.snyk.agent.logic.DataTracker;
 import io.snyk.agent.logic.ReportingWorker;
-import io.snyk.agent.util.FileLog;
-import io.snyk.agent.util.InitLog;
-import io.snyk.agent.util.Log;
+import io.snyk.agent.util.*;
 
 import java.io.File;
 import java.lang.instrument.Instrumentation;
@@ -25,7 +23,20 @@ class EntryPoint {
 
         final Config config = Config.fromFileWithDefault(configFile.getAbsolutePath());
 
-        final Log log = new FileLog(configFile.getParentFile(), config.debugLoggingEnabled);
+        final Log log;
+        switch (config.logTo) {
+            case FILE:
+                log = new FileLog(configFile.getParentFile(), config.debugLoggingEnabled);
+                break;
+            case STDERR:
+                log = new StdErrLog(config.debugLoggingEnabled);
+                break;
+            case NOWHERE:
+                log = new NullLog();
+                break;
+            default:
+                throw new IllegalStateException();
+        }
         InitLog.flushToInstance(log);
 
         log.info("loading config complete, projectId:" + config.projectId);

--- a/src/main/java/io/snyk/agent/logic/Config.java
+++ b/src/main/java/io/snyk/agent/logic/Config.java
@@ -25,6 +25,7 @@ public class Config {
     public final long heartBeatIntervalMs;
     public final long reportIntervalMs;
     public final boolean trackClassLoading;
+    public final LogDestinationConfig logTo;
     public final boolean debugLoggingEnabled;
     public final boolean trackBranchingMethods;
     public final boolean trackAccessors;
@@ -43,6 +44,7 @@ public class Config {
            boolean trackClassLoading,
            boolean trackAccessors,
            boolean trackBranchingMethods,
+           String logTo,
            boolean debugLoggingEnabled,
            boolean skipBuiltInRules,
            boolean skipMetaPosts) {
@@ -66,6 +68,7 @@ public class Config {
         this.reportIntervalMs = reportIntervalMs;
         this.trackClassLoading = trackClassLoading;
         this.trackAccessors = trackAccessors;
+        this.logTo = LogDestinationConfig.fromNullableString(logTo);
         this.debugLoggingEnabled = debugLoggingEnabled;
         this.trackBranchingMethods = trackBranchingMethods;
         this.skipBuiltInRules = skipBuiltInRules;
@@ -145,6 +148,11 @@ public class Config {
 
             if ("trackBranchingMethods".equals(key)) {
                 builder.trackBranchingMethods = Boolean.parseBoolean(value);
+                continue;
+            }
+
+            if ("logTo".equals(key)) {
+                builder.logTo = value;
                 continue;
             }
 

--- a/src/main/java/io/snyk/agent/logic/ConfigBuilder.java
+++ b/src/main/java/io/snyk/agent/logic/ConfigBuilder.java
@@ -19,6 +19,7 @@ class ConfigBuilder {
     boolean trackClassLoading;
     boolean trackAccessors;
     boolean trackBranchingMethods;
+    String logTo;
     boolean debugLoggingEnabled;
     boolean skipBuiltInRules;
     boolean skipMetaPosts;
@@ -27,6 +28,6 @@ class ConfigBuilder {
         return new Config(projectId, filters, homeBaseUrl, homeBasePostLimit,
                 startupDelayMs, heartBeatIntervalMs, reportIntervalMs,
                 trackClassLoading, trackAccessors, trackBranchingMethods,
-                debugLoggingEnabled, skipBuiltInRules, skipMetaPosts);
+                logTo, debugLoggingEnabled, skipBuiltInRules, skipMetaPosts);
     }
 }

--- a/src/main/java/io/snyk/agent/logic/LogDestinationConfig.java
+++ b/src/main/java/io/snyk/agent/logic/LogDestinationConfig.java
@@ -1,0 +1,23 @@
+package io.snyk.agent.logic;
+
+public enum LogDestinationConfig {
+    FILE,
+    STDERR,
+    NOWHERE;
+
+    static LogDestinationConfig fromNullableString(String input) {
+        if (null == input) {
+            return FILE;
+        }
+        switch (input) {
+            case "file":
+                return FILE;
+            case "stderr":
+                return STDERR;
+            case "nowhere":
+                return NOWHERE;
+            default:
+                throw new IllegalStateException("unrecognised log destination: " + input);
+        }
+    }
+}

--- a/src/main/java/io/snyk/agent/util/NullLog.java
+++ b/src/main/java/io/snyk/agent/util/NullLog.java
@@ -1,0 +1,23 @@
+package io.snyk.agent.util;
+
+public class NullLog implements Log {
+    @Override
+    public void debug(String msg) {
+    }
+
+    @Override
+    public void info(String msg) {
+    }
+
+    @Override
+    public void warn(String msg) {
+    }
+
+    @Override
+    public void stackTrace(Throwable e) {
+    }
+
+    @Override
+    public void flushInitMessage(String initMessage) {
+    }
+}

--- a/src/main/java/io/snyk/agent/util/StdErrLog.java
+++ b/src/main/java/io/snyk/agent/util/StdErrLog.java
@@ -1,0 +1,38 @@
+package io.snyk.agent.util;
+
+public class StdErrLog implements Log {
+    private final boolean debugLoggingEnabled;
+
+    public StdErrLog(boolean debugLoggingEnabled) {
+        this.debugLoggingEnabled = debugLoggingEnabled;
+    }
+
+    @Override
+    public void debug(String msg) {
+        if (debugLoggingEnabled) {
+            System.err.println(FileLog.makeLine("debug: " + msg));
+        }
+    }
+
+    @Override
+    public void info(String msg) {
+        System.err.println(FileLog.makeLine(" info: " + msg));
+    }
+
+    @Override
+    public void warn(String msg) {
+        System.err.println(FileLog.makeLine(" warn: " + msg));
+
+    }
+
+    @Override
+    public void stackTrace(Throwable e) {
+        System.err.println(FileLog.makeLine(" exception"));
+        e.printStackTrace();
+    }
+
+    @Override
+    public void flushInitMessage(String initMessage) {
+        // were already printed by `InitLog`
+    }
+}


### PR DESCRIPTION
### What this does

Three new config options:
 * `logTo=file`: the existing behaviour of writing to `${JAR_LOCATION}/snyk-logs/snyk-agent....log`
 * `logTo=stderr`: write logs immediately to stderr. This is now used in the e2e test.
 * `logTo=nowhere`: discard logs

The default is still `file`.

### Notes for the reviewer

This looks like a big change but is actually tiny; the new classes (`NullLog`, `StdErrLog`) have no logic in them, just lots of Java verbosity.

### More information

- [Jira ticket SC-6727](https://snyksec.atlassian.net/browse/SC-6727)
