### PR TITLE
feat: actually send if-modified-since

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
     testCompile("org.apache.commons:commons-text:1.4")
     testCompile("com.google.code.gson:gson:2.8.5")
     testCompile("com.google.guava:guava:26.0-jre")
+    testCompile("org.mockito:mockito-core:2.23.4")
+    testCompile("com.github.tomakehurst:wiremock:2.20.0")
     testCompile("org.junit.jupiter:junit-jupiter-api:5.3.1")
     testCompile("org.junit.jupiter:junit-jupiter-params:5.3.1")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:5.3.1")

--- a/src/test/java/io/snyk/agent/filter/FilterTest.java
+++ b/src/test/java/io/snyk/agent/filter/FilterTest.java
@@ -3,6 +3,7 @@ package io.snyk.agent.filter;
 import io.snyk.agent.testutil.TestLogger;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
@@ -18,7 +19,7 @@ class FilterTest {
         final FilterList filter = new FilterList(Collections.singletonList(new Filter("foo",
                 Optional.of("maven:io.snyk:snyk-agent"),
                 Optional.empty(),
-                Collections.singletonList(PathFilter.parse("**")))));
+                Collections.singletonList(PathFilter.parse("**")))), Instant.EPOCH);
 
         assertTrue(filter.shouldProcessClass(LOG, Collections.emptyList(), "A"),
                 "a class that we know nothing about the heritage of");
@@ -38,7 +39,7 @@ class FilterTest {
                 new Filter("foo",
                         Optional.of("maven:io.snyk:snyk-agent"),
                         Optional.of(VersionFilter.parse("[,3)")),
-                        Collections.singletonList(PathFilter.parse("**")))));
+                        Collections.singletonList(PathFilter.parse("**")))), Instant.EPOCH);
 
         assertTrue(filters.shouldProcessClass(LOG, Collections.emptyList(), "NotUsed"),
                 "a class that we know nothing about the heritage of");

--- a/src/test/java/io/snyk/agent/logic/ConfigTest.java
+++ b/src/test/java/io/snyk/agent/logic/ConfigTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
@@ -34,7 +35,7 @@ public class ConfigTest {
 
     public static Config makeConfig(Iterable<String> configLines, Iterable<String> filterLines) {
         final Config config = Config.loadConfig(configLines);
-        config.filters.set(FilterList.loadFiltersFrom(new TestLogger(), filterLines));
+        config.filters.set(FilterList.loadFiltersFrom(new TestLogger(), filterLines, Instant.EPOCH));
         return config;
     }
 }

--- a/src/test/java/io/snyk/agent/logic/FilterUpdateTest.java
+++ b/src/test/java/io/snyk/agent/logic/FilterUpdateTest.java
@@ -1,0 +1,61 @@
+package io.snyk.agent.logic;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.snyk.agent.filter.FilterList;
+import io.snyk.agent.testutil.TestLogger;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.instrument.Instrumentation;
+import java.net.URL;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.*;
+
+class FilterUpdateTest {
+
+    @Test
+    void ifModified() throws Exception {
+        final WireMockServer wireMock = new WireMockServer(wireMockConfig().dynamicPort());
+        wireMock.start();
+
+        final Instrumentation ins = Mockito.mock(Instrumentation.class);
+        AtomicReference<FilterList> filters = new AtomicReference<>(FilterList.empty());
+
+        final String TEST_URL = "/test/get-java";
+
+        wireMock.stubFor(get(urlEqualTo(TEST_URL))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
+                        .withBody("filter.test-1.paths = foo/bar#quux")));
+
+        wireMock.stubFor(get(urlEqualTo(TEST_URL))
+                .withHeader("If-Modified-Since", equalTo("Wed, 21 Oct 2015 07:28:00 GMT"))
+                .willReturn(aResponse()
+                        .withStatus(304) // not-modified
+                        .withBody("")));
+
+
+        assertEquals(Collections.emptyList(), filters.get().filters);
+
+        final FilterUpdate filterUpdate = new FilterUpdate(
+                new TestLogger(),
+                ins,
+                () -> {
+                },
+                new URL("http://localhost:" + wireMock.port() + TEST_URL),
+                filters,
+                1);
+
+        assertTrue(filterUpdate.fetchUpdatedAnything(), "server has newer file, so we update");
+        assertEquals(1, filters.get().filters.size(), "update picked up the new rule");
+        assertFalse(filterUpdate.fetchUpdatedAnything(), "server has the same file, so we don't update");
+        assertEquals(1, filters.get().filters.size(), "same rules as before");
+
+        wireMock.stop();
+    }
+}


### PR DESCRIPTION
### What this does

Send the `If-Modified-Since` header, using the date of the last `Last-Modified` we'd seen. The code already handled the 304 (which would never be hit).

All of the rest of the change is for the test, because the e2e test doesn't actually test this logic, because the mock http server we're using (literally just the filesystem) doesn't honour `if-modified-since`. Amusingly, it *does* honour `last-modified`.

### Notes for the reviewer

Branched from #42, merge that first.
