### PR TITLE
feat: Support new snapshot bundling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ jdk:
 script:
 - pyenv versions
 - pyenv global 3.6
+- curl $SNAPSHOT_URL > src/main/resources/methods.bundled.properties
+# - node -e "console.log('filters.provided.generated =', new Date().toISOString())" >> src/main/resources/methods.bundled.properties
 - ./gradlew build test distZip
-- git clone --depth 1 --branch java9 https://github.com/snyk/java-goof
+- git clone --depth 1 --branch java9-modified https://github.com/snyk/java-goof
 - e2e/test-script.sh
 - e2e/test-reload.py
 branches:


### PR DESCRIPTION
- [ ] Tests written [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
- Bundles the new snapshot on every build
- The agent tries to load the bundled snapshot, with the previous committed snapshot as a fallback

### Notes for the reviewer
- The comment in the travis.yaml file is for future use
- Changed the testing branch of java-goof to java9-modified in which struts2 was upgraded to 2.5.1 (to make the tests pass)