### PR TITLE
Feat/add shutdown hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ script:
 - git clone --depth 1 --branch java9-modified https://github.com/snyk/java-goof
 - e2e/test-script.sh
 - e2e/test-reload.py
+- e2e/test-shutdown.py
 branches:
   only:
   - master

--- a/e2e/test-shutdown.py
+++ b/e2e/test-shutdown.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+import json
+import os
+import re
+import subprocess
+import tempfile
+from os import path
+from time import sleep
+from typing import Iterable
+
+
+def main():
+    d = tempfile.TemporaryDirectory()
+    project_id = '0153525f-5a99-4efe-a84f-454f12494034'
+    CONFIG = """
+projectId={}
+homeBaseUrl=file://{}/
+logTo=stderr
+
+debugLoggingEnabled=true
+
+startupDelayMs=10
+filterUpdateIntervalMs=800
+heartBeatIntervalMs=500
+reportIntervalMs=100000000
+""".format(project_id, d.name)
+    config_path = path.join(d.name, 'snyk.properties')
+
+    with open(config_path, 'w') as f:
+        f.write(CONFIG)
+
+    victim = subprocess.Popen([
+        'java',
+        '-javaagent:{}=file://{}'.format(
+            path.join(os.getcwd(), 'build/libs/snyk-java-runtime-agent.jar'),
+            config_path
+        ),
+        '-jar',
+        'e2e/repeat-action/build/libs/repeat-action.jar'
+    ])
+
+    # We're expecting the startup to take between 40ms and 6s. We've seen
+    # 6s in the wild, e.g. on OSX resolving host-names. The app will produce
+    # events for 10s after startup, so we'd expect between 2.5 and 8.5s of
+    # events from the app. We only need 0.5s, so this is a pretty good safety
+    # margin.
+    sleep(7.5)
+
+    # shouldn't've seen any events yet
+    assert [] == list(all_seen_events(d.name))
+
+    update_dir = path.join(d.name, 'v2', 'snapshot/{}'.format(project_id))
+    os.makedirs(update_dir)
+    update_file = path.join(update_dir, 'java')
+
+    expected_paths = [
+        'demo/CalledFromExecutor#run',
+        'demo/ConstructedFromExecutor#foo',
+        'demo/LoopWithSleep#foo',
+    ]
+
+    also_try = [
+        'demo/LoopWithSleep#run',
+    ]
+
+    new_filters = ''
+    for i, wanted in enumerate(expected_paths + also_try):
+        new_filters += 'filter.up-{}.paths = {}\n'.format(i, wanted)
+
+    with open(update_file, 'w') as f:
+        f.write(new_filters)
+    print('>>> update written to {}'.format(update_file))
+
+    # test app should run for >2 more seconds, so >4 more reloads and reports
+    victim.wait(4)
+
+    seen_methods = set()
+    for entry in all_seen_events(d.name):
+        seen_methods.add(re.sub(r'\(.*', '', entry['methodEntry']['methodName']))
+
+    print('    seen: {}'.format(sorted(seen_methods)))
+    print('expected: {}'.format(sorted(expected_paths)))
+    assert seen_methods == set(expected_paths)
+
+    print('Success!')
+
+
+def all_seen_events(out_dir: str) -> Iterable:
+    for name in os.listdir(out_dir):
+        if not name.startswith('post-'):
+            continue
+        name = path.join(out_dir, name)
+        with open(name) as f:
+            doc = json.load(f)
+        if 'eventsToSend' in doc:
+            yield from doc['eventsToSend']
+
+
+if '__main__' == __name__:
+    main()

--- a/src/main/java/io/snyk/agent/logic/Config.java
+++ b/src/main/java/io/snyk/agent/logic/Config.java
@@ -31,6 +31,7 @@ public class Config {
     public final boolean trackAccessors;
     public final boolean skipBuiltInRules;
     public final boolean skipMetaPosts;
+    public final boolean addShutdownHook;
 
     private static final long DEFAULT_POST_LIMIT = 1024 * 1024;
 
@@ -46,7 +47,8 @@ public class Config {
            String logTo,
            boolean debugLoggingEnabled,
            boolean skipBuiltInRules,
-           boolean skipMetaPosts) {
+           boolean skipMetaPosts,
+           boolean addShutdownHook) {
         if (null == projectId) {
             throw new IllegalStateException("projectId is required");
         }
@@ -70,6 +72,7 @@ public class Config {
         this.trackBranchingMethods = trackBranchingMethods;
         this.skipBuiltInRules = skipBuiltInRules;
         this.skipMetaPosts = skipMetaPosts;
+        this.addShutdownHook = addShutdownHook;
     }
 
     public static Config loadConfigFromFile(String path) {
@@ -141,6 +144,10 @@ public class Config {
 
                 case "skipMetaPosts":
                     builder.skipMetaPosts = Boolean.parseBoolean(value);
+                    return;
+
+                case "addShutdownHook":
+                    builder.addShutdownHook = Boolean.parseBoolean(value);
                     return;
 
                 case "homeBaseUrl":

--- a/src/main/java/io/snyk/agent/logic/ConfigBuilder.java
+++ b/src/main/java/io/snyk/agent/logic/ConfigBuilder.java
@@ -14,6 +14,7 @@ class ConfigBuilder {
     long reportIntervalMs = MINUTE_MS;
     long filterUpdateIntervalMs = 60 * MINUTE_MS;
     long filterUpdateInitialDelayMs = 1_000;
+    boolean addShutdownHook = true;
 
     boolean trackClassLoading;
     boolean trackAccessors;
@@ -28,6 +29,7 @@ class ConfigBuilder {
                 startupDelayMs, heartBeatIntervalMs, reportIntervalMs,
                 filterUpdateIntervalMs, filterUpdateInitialDelayMs,
                 trackClassLoading, trackAccessors, trackBranchingMethods,
-                logTo, debugLoggingEnabled, skipBuiltInRules, skipMetaPosts);
+                logTo, debugLoggingEnabled, skipBuiltInRules, skipMetaPosts,
+                addShutdownHook);
     }
 }


### PR DESCRIPTION
- [x] Tests written [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

an initial attempt at setting a shutdown hook for the agent that sends one last report before shutting down.
this is mostly useful for short-lived environments (such as testing environments) where the agent doesn't get a chance to report its findings before terminating.

~~this still needs a lot more work:~~
1. ~~adding a locking mechanism (unless we learn that we don't need one) in case the shutdown hook is triggered when a report is already in progress (or vice versa)~~
2. ~~determining whether or not this is exactly the behaviour we want (in the Node agent we report only if the Node process ran out of "things" to do, while here at the moment it will also happen when the VM is terminated in response to a user interrupt)~~ I think it is?
3. ~~add proper testing~~
4. ~~seeing this actually happen~~

### More information

https://snyksec.atlassian.net/browse/RUN-125
### Screenshots
