### PR TITLE
feat: finite logging

### DIFF
--- a/src/main/java/io/snyk/agent/jvm/EntryPoint.java
+++ b/src/main/java/io/snyk/agent/jvm/EntryPoint.java
@@ -71,7 +71,7 @@ class EntryPoint {
         instrumentation.addTransformer(new Transformer(log, config, dataTracker), canReTransform);
 
         if (!initialFetchComplete.await(config.filterUpdateInitialDelayMs, TimeUnit.MILLISECONDS)) {
-            log.info("releasing agent as data refresh fetch timed out");
+            log.warn("releasing agent as data refresh fetch timed out");
         } else {
             log.info("startup complete, releasing application");
         }

--- a/src/main/java/io/snyk/agent/logic/Rewriter.java
+++ b/src/main/java/io/snyk/agent/logic/Rewriter.java
@@ -64,20 +64,20 @@ public class Rewriter {
             }
 
             if (InstrumentationFilter.skipMethod(cn, method)) {
-                log.info("rewrite requested, but disallowed: " + logName);
+                log.warn("rewrite requested, but disallowed: " + logName);
                 continue;
             }
 
             final boolean includeWrtAccessors = config.trackAccessors || !InstrumentationFilter.isAccessor(method);
             if (!includeWrtAccessors) {
-                log.info("rewrite requested, but accessor: " + logName);
+                log.warn("rewrite requested, but accessor: " + logName);
                 continue;
             }
 
             final boolean includeWrtBranching = config.trackBranchingMethods ||
                     InstrumentationFilter.branches(cn, method);
             if (!includeWrtBranching) {
-                log.info("rewrite requested, but branching: " + logName);
+                log.warn("rewrite requested, but branching: " + logName);
                 continue;
             }
 
@@ -86,7 +86,7 @@ public class Rewriter {
         }
 
         if (!aMethodHadTheRightName) {
-            log.info("rewrite requested, but no matching method found: " + cn.name);
+            log.debug("rewrite requested, but no matching method found: " + cn.name);
         }
 
         return AsmUtil.byteArray(cn);


### PR DESCRIPTION
Don't generate unbounded log files with only `info` logging enabled, primarily by removing the `info` logging of HTTP responses.

Currently we generate around 100MB a year, which is considered too much.

### Notes for the reviewer

`info` and `warn` are essentially the same at the moment, they just change the message printed.

#44 may be changing some of the `warn` lines to send events to homebass.


### More information

- [Jira ticket](https://snyksec.atlassian.net/browse/RUN-151)
