### PR TITLE
docs: link to java-woof

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 ## java-runtime-agent
 
-### Usage
+### Getting started
+
+The best way to get started with the agent is to run
+[the example project, java-woof](https://github.com/snyk/java-woof#java-woof).
+Head over there for a getting started guide.
+
+
+### Developing
 
 Build is using `gradle`. You can use the wrapper, if you don't have `gradle`:
 


### PR DESCRIPTION
### What this does

Add a note to the README that `java-woof` is a good place to start.

### Notes for the reviewer

It would be nice if we could eventually eliminate `java-goof`, which is still used elsewhere in the readme. Unfortunately, the local dev workflow with `java-woof` is nowhere near as smooth as with `java-goof`, which is not set up so defensively, and has been edited to work better with our local dev. Having separate projects for these separate tasks isn't too insane.