### PR TITLE
feat: re-roundtrip filter name

### DIFF
--- a/e2e/test-reload.py
+++ b/e2e/test-reload.py
@@ -76,6 +76,7 @@ reportIntervalMs=1000
 
     seen_methods = set()
     for entry in all_seen_events(d.name):
+        assert entry['methodEntry']['filterName'].startswith('up-')
         seen_methods.add(re.sub(r'\(.*', '', entry['methodEntry']['methodName']))
 
     print('    seen: {}'.format(sorted(seen_methods)))

--- a/src/main/java/io/snyk/agent/filter/FilterList.java
+++ b/src/main/java/io/snyk/agent/filter/FilterList.java
@@ -8,10 +8,14 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.time.Instant;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class FilterList {
+    // Must *not* contain colons, which we use as a delimiter internally
+    private static final Pattern VALID_FILTER_NAME = Pattern.compile("[a-zA-Z0-9_-]+");
+
     public final List<Filter> filters;
     public final Instant generated;
 
@@ -56,6 +60,11 @@ public class FilterList {
             }
 
             final String filterName = parts[1];
+
+            if (!VALID_FILTER_NAME.matcher(filterName).matches()) {
+                throw new IllegalStateException("invalid filter name: " + filterName);
+            }
+
             final String filterCommand = parts[2];
 
             final Filter.Builder filter = filters.computeIfAbsent(filterName, Filter.Builder::new);

--- a/src/main/java/io/snyk/agent/logic/ReportingWorker.java
+++ b/src/main/java/io/snyk/agent/logic/ReportingWorker.java
@@ -234,11 +234,12 @@ public class ReportingWorker implements Runnable {
     }
 
     private void appendMethodEntry(StringBuilder msg, String rawLocator) {
-        final String[] parts = rawLocator.split(":", 4);
-        final String className = parts[0];
-        final String methodName = parts[1];
-        final String classCrc32c = parts[2];
-        final String sourceUrl = parts[3];
+        final String[] parts = rawLocator.split(":", 5);
+        final String filterName = parts[0];
+        final String className = parts[1];
+        final String methodName = parts[2];
+        final String classCrc32c = parts[3];
+        final String sourceUrl = parts[4];
         final URI sourceUri = URI.create(sourceUrl);
         msg.append("{\"methodEntry\":{");
         msg.append("\"source\":\"java-agent\",");
@@ -254,6 +255,8 @@ public class ReportingWorker implements Runnable {
         Json.appendString(msg, className + "#" + methodName);
         msg.append(",\"sourceUri\":");
         Json.appendString(msg, sourceUrl);
+        msg.append(",\"filterName\":");
+        Json.appendString(msg, filterName);
         msg.append(",\"sourceCrc32c\":");
         Json.appendString(msg, classCrc32c);
         msg.append("},\"timestamp\":");

--- a/src/main/java/io/snyk/agent/logic/Rewriter.java
+++ b/src/main/java/io/snyk/agent/logic/Rewriter.java
@@ -82,7 +82,7 @@ public class Rewriter {
             }
 
             log.info("rewrite: " + logName);
-            rewriteMethod(cn.name, method);
+            rewriteMethod(filter.name, cn.name, method);
         }
 
         if (!aMethodHadTheRightName) {
@@ -92,14 +92,25 @@ public class Rewriter {
         return AsmUtil.byteArray(cn);
     }
 
-    private void rewriteMethod(String clazzInternalName, MethodNode method) {
-        final String tag = clazzInternalName + ":" + method.name +
-                method.desc + // using desc, not signature, as it's always available
-                ":" + sourceLocation;
+    private void rewriteMethod(String filterName, String clazzInternalName, MethodNode method) {
+        final String tag = noColons(filterName) + ":"
+                + noColons(clazzInternalName) + ":"
+                + noColons(method.name)
+                + noColons(method.desc) // using desc, not signature, as it's always available
+                + ":" + sourceLocation;
+
         if (config.trackClassLoading) {
             addInspectionOfLoadClassCalls(method, tag);
         }
         addInspectionOfMethodEntry(method, tag);
+    }
+
+    private static String noColons(String value) {
+        if (value.contains(":")) {
+            throw new IllegalStateException("must not contain a colon: " + value);
+        }
+
+        return value;
     }
 
     private void addInspectionOfMethodEntry(MethodNode method, String methodLocation) {

--- a/src/test/java/io/snyk/agent/logic/ReportingWorkerTest.java
+++ b/src/test/java/io/snyk/agent/logic/ReportingWorkerTest.java
@@ -98,10 +98,10 @@ class ReportingWorkerTest {
 
     @Test
     void serialiseWeirdListSizesCorrectly() throws IOException {
-        onlyDrain(drain -> drain.methodEntries.add("foo:bar:baz:quux"));
+        onlyDrain(drain -> drain.methodEntries.add("filt:foo:bar:baz:quux"));
         onlyDrain(drain -> {
-            drain.methodEntries.add("foo:bar:baz:quux");
-            drain.methodEntries.add("bar:bar:baz:quux");
+            drain.methodEntries.add("filt:foo:bar:baz:quux");
+            drain.methodEntries.add("filt:bar:bar:baz:quux");
         });
 
         onlyDrain(drain -> drain.loadClasses.put("foo", Sets.newHashSet()));

--- a/src/test/java/io/snyk/agent/logic/RewriterTest.java
+++ b/src/test/java/io/snyk/agent/logic/RewriterTest.java
@@ -26,7 +26,7 @@ class RewriterTest {
         final Object instance = clazz.newInstance();
         assertNotNull(clazz.getDeclaredMethod("returnLambda").invoke(instance));
         assertEquals(Sets.newHashSet(
-                "io/snyk/agent/logic/TestVictim:returnLambda()Ljava/util/concurrent/Callable;:" + TEST_LOCATION),
+                "foo:io/snyk/agent/logic/TestVictim:returnLambda()Ljava/util/concurrent/Callable;:" + TEST_LOCATION),
                 TestTracker.SEEN_SET.drain().methodEntries);
     }
 


### PR DESCRIPTION
### What this does

Passes the provided filter name back with the matched events

### Notes for the reviewer

This conflicts horribly with #44, I sure hope we aren't merging both.

All of the places we have to update nonsense strings are gross tests of internals.