### PR TITLE
feat: allowUnknownCA

### DIFF
--- a/src/main/java/io/snyk/agent/jvm/CrippleSSL.java
+++ b/src/main/java/io/snyk/agent/jvm/CrippleSSL.java
@@ -1,0 +1,49 @@
+package io.snyk.agent.jvm;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.net.URLConnection;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+
+public class CrippleSSL {
+    private static final X509TrustManager IGNORE_EVERYTHING_TRUST_MANAGER = new X509TrustManager() {
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    };
+
+    /**
+     * Disable CA and hostname verification on a connection, if it's an HTTPS connection.
+     */
+    public static void cripple(URLConnection conn) {
+        if (!(conn instanceof HttpsURLConnection)) {
+            return;
+        }
+
+        final HttpsURLConnection sslConn = (HttpsURLConnection) conn;
+
+        try {
+            final SSLContext crippledContext = SSLContext.getInstance("SSL");
+            crippledContext.init(null, new TrustManager[]{IGNORE_EVERYTHING_TRUST_MANAGER}, new SecureRandom());
+            sslConn.setSSLSocketFactory(crippledContext.getSocketFactory());
+            sslConn.setHostnameVerifier((_anyName, _anySession) -> true);
+        } catch (KeyManagementException | NoSuchAlgorithmException e) {
+            throw new IllegalStateException("unable to disable ssl validation", e);
+        }
+    }
+}

--- a/src/main/java/io/snyk/agent/logic/Config.java
+++ b/src/main/java/io/snyk/agent/logic/Config.java
@@ -19,6 +19,7 @@ public class Config {
     public final AtomicReference<FilterList> filters;
     public final URI homeBaseUrl;
     public final long homeBasePostLimit;
+    public final boolean allowUnknownCA;
     public final long startupDelayMs;
     public final long heartBeatIntervalMs;
     public final long reportIntervalMs;
@@ -38,6 +39,7 @@ public class Config {
     Config(String projectId,
            String homeBaseUrl,
            Long homeBasePostLimit,
+           boolean allowUnknownCA,
            long startupDelayMs,
            long heartBeatIntervalMs,
            long reportIntervalMs,
@@ -60,6 +62,7 @@ public class Config {
         } else {
             this.homeBasePostLimit = homeBasePostLimit;
         }
+        this.allowUnknownCA = allowUnknownCA;
         this.startupDelayMs = startupDelayMs;
         this.heartBeatIntervalMs = heartBeatIntervalMs;
         this.reportIntervalMs = reportIntervalMs;
@@ -152,6 +155,10 @@ public class Config {
 
                 case "homeBaseUrl":
                     builder.homeBaseUrl = value;
+                    return;
+
+                case "allowUnknownCA":
+                    builder.allowUnknownCA = Boolean.parseBoolean(value);
                     return;
 
                 case "skipBuiltInRules":

--- a/src/main/java/io/snyk/agent/logic/ConfigBuilder.java
+++ b/src/main/java/io/snyk/agent/logic/ConfigBuilder.java
@@ -9,6 +9,7 @@ class ConfigBuilder {
     String projectId;
     String homeBaseUrl;
     Long homeBasePostLimit;
+    boolean allowUnknownCA = false;
     long startupDelayMs = 1_000;
     long heartBeatIntervalMs = MINUTE_MS / 2;
     long reportIntervalMs = MINUTE_MS;
@@ -26,7 +27,7 @@ class ConfigBuilder {
 
     Config build() {
         return new Config(projectId, homeBaseUrl, homeBasePostLimit,
-                startupDelayMs, heartBeatIntervalMs, reportIntervalMs,
+                allowUnknownCA, startupDelayMs, heartBeatIntervalMs, reportIntervalMs,
                 filterUpdateIntervalMs, filterUpdateInitialDelayMs,
                 trackClassLoading, trackAccessors, trackBranchingMethods,
                 logTo, debugLoggingEnabled, skipBuiltInRules, skipMetaPosts,

--- a/src/test/java/io/snyk/agent/jvm/CrippleSSLTest.java
+++ b/src/test/java/io/snyk/agent/jvm/CrippleSSLTest.java
@@ -1,0 +1,33 @@
+package io.snyk.agent.jvm;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CrippleSSLTest {
+    @Test
+    void againstBadSslCom() throws IOException {
+        final URL testServer = new URL("https://self-signed.badssl.com/");
+        final URLConnection failingConn = testServer.openConnection();
+        try {
+            failingConn.connect();
+            failingConn.getInputStream().close();
+            failingConn.getOutputStream().close();
+            fail("default validation not working");
+        } catch (IOException ignored) {
+        }
+
+        final URLConnection workingConn = testServer.openConnection();
+        CrippleSSL.cripple(workingConn);
+        workingConn.connect();
+        final InputStream is = workingConn.getInputStream();
+        assertNotEquals(-1, is.read());
+        is.close();
+    }
+}

--- a/src/test/java/io/snyk/agent/logic/FilterUpdateTest.java
+++ b/src/test/java/io/snyk/agent/logic/FilterUpdateTest.java
@@ -52,6 +52,7 @@ class FilterUpdateTest {
                 },
                 new URL("http://localhost:" + wireMock.port() + TEST_URL),
                 filters,
+                false,
                 1);
 
         assertTrue(filterUpdate.fetchUpdatedAnything(), "server has newer file, so we update");


### PR DESCRIPTION
- [ ] Tests written [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Add a config option to cripple https/ssl/tls, ignoring both CA/certificate authorities entirely, and ignoring hostname verification.

### Notes for the reviewer

The integration of the configuration option and the new code was tested manually.
The new code is only tested against badssl.com, which we should host an alternative to internally.