### PR TITLE
chore: bump test dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
 script:
 - pyenv global 3.6
 - curl $SNAPSHOT_URL > src/main/resources/methods.bundled.properties
-- ./gradlew build test distZip
+- ./gradlew build test distZip dependencyUpdates
 - make test
 branches:
   only:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,9 +3,10 @@ import groovy.lang.Closure
 
 plugins {
     id("com.github.johnrengelman.shadow") version "2.0.4"
-    id("me.champeau.gradle.jmh") version "0.4.7"
+    id("me.champeau.gradle.jmh") version "0.4.8"
     // 0.12*rc* drops requirement on native git, which might be useful
     id("com.palantir.git-version") version "0.12.0-rc2"
+    id("com.github.ben-manes.versions") version "0.21.0"
     java
     distribution
 }
@@ -14,13 +15,13 @@ dependencies {
     compile(files("$projectDir/tools/repack/asm-re-7.1.jar"))
     testCompile("org.apache.commons:commons-text:1.6")
     testCompile("com.google.code.gson:gson:2.8.5")
-    testCompile("com.google.guava:guava:27.0.1-jre")
-    testCompile("org.mockito:mockito-core:2.23.4")
-    testCompile("com.github.tomakehurst:wiremock:2.20.0")
-    testCompile("org.junit.jupiter:junit-jupiter-api:5.3.2")
-    testCompile("org.junit.jupiter:junit-jupiter-params:5.3.2")
-    testRuntime("org.junit.jupiter:junit-jupiter-engine:5.3.2")
-    jmh("com.google.guava:guava:27.0.1-jre")
+    testCompile("com.google.guava:guava:27.1-jre")
+    testCompile("org.mockito:mockito-core:2.28.2")
+    testCompile("com.github.tomakehurst:wiremock:2.23.2")
+    testCompile("org.junit.jupiter:junit-jupiter-api:5.4.2")
+    testCompile("org.junit.jupiter:junit-jupiter-params:5.4.2")
+    testRuntime("org.junit.jupiter:junit-jupiter-engine:5.4.2")
+    jmh("com.google.guava:guava:27.1-jre")
 }
 
 fun extendedVersion(): String {
@@ -121,6 +122,6 @@ repositories {
 }
 
 tasks.withType<Wrapper> {
-    gradleVersion = "5.2.1"
+    gradleVersion = "5.4.1"
     distributionType = Wrapper.DistributionType.ALL
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import groovy.lang.Closure
 
@@ -124,4 +125,25 @@ repositories {
 tasks.withType<Wrapper> {
     gradleVersion = "5.4.1"
     distributionType = Wrapper.DistributionType.ALL
+}
+
+// https://github.com/ben-manes/gradle-versions-plugin#revisions
+tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
+    resolutionStrategy {
+        componentSelection {
+            all {
+                val rejected = listOf("alpha", "beta", "rc", "cr", "m", "preview", "b", "ea").any { qualifier ->
+                    candidate.version.matches(Regex("(?i).*[.-]$qualifier[.\\d-+]*"))
+                }
+                if (rejected) {
+                    reject("Release candidate")
+                }
+            }
+        }
+    }
+    // optional parameters
+    checkForGradleUpdate = true
+    outputFormatter = "json"
+    outputDir = "build/dependencyUpdates"
+    reportfileName = "report"
 }


### PR DESCRIPTION
### What this does

Make sure we don't fall behind on any test dependencies.

The `versions` plugin allows `./gradlew dependencyUpdates`, which shows a report. The configuration, copied verbatim from the docs, stops it suggesting updates to RC/beta versions.