### PR TITLE
feat: network test debugger

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,7 @@ tasks.withType<Jar> {
         attributes(mapOf(
             "Extended-Version-Info" to extendedVersion(),
             "Premain-Class" to "io.snyk.agent.jvm.EntryPoint",
+            "Main-Class" to "io.snyk.agent.jvm.EntryPoint",
             "Can-Retransform-Classes" to true
         ))
     }

--- a/src/main/java/io/snyk/agent/jvm/EntryPoint.java
+++ b/src/main/java/io/snyk/agent/jvm/EntryPoint.java
@@ -16,6 +16,17 @@ import java.util.concurrent.TimeUnit;
  * The entry point for the agent. Load and install our plugins.
  */
 class EntryPoint {
+    public static void main(String... args) throws Exception {
+        if (2 == args.length && "network-test".equals(args[0])) {
+            NetworkTest.run(args[1]);
+            return;
+        }
+
+        System.err.println("This is not an executable jar.");
+        System.err.println();
+        System.err.println("Please refer to the installation instructions.");
+    }
+
     public static void premain(
             String agentArguments,
             Instrumentation instrumentation) throws Exception {

--- a/src/main/java/io/snyk/agent/jvm/NetworkTest.java
+++ b/src/main/java/io/snyk/agent/jvm/NetworkTest.java
@@ -1,0 +1,45 @@
+package io.snyk.agent.jvm;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+class NetworkTest {
+    static void run(String arg) throws IOException {
+        log("Connection test");
+        final URL url = new URL(arg);
+        log("Testing connection to: " + url);
+        log("Protocol: " + url.getProtocol());
+        final URLConnection conn = url.openConnection();
+        log("Connection ready.");
+        conn.connect();
+        log("Connection initiated.");
+        boolean shouldRead = true;
+        if (conn instanceof HttpURLConnection) {
+            final HttpURLConnection http = (HttpURLConnection) conn;
+            final int responseCode = http.getResponseCode();
+            log("Response code: " + responseCode);
+
+            shouldRead = (responseCode / 100) == 2;
+        }
+
+        if (shouldRead) {
+            log("Attempting to read.");
+            byte[] buf = new byte[8 * 1024];
+            int len = conn.getInputStream().read(buf);
+            log("Response prefix: " + new String(buf, 0, len, StandardCharsets.ISO_8859_1));
+        } else {
+            log("Read not attempted.");
+        }
+
+        log("Complete.");
+    }
+
+    private static void log(String message) {
+        System.out.println(DateTimeFormatter.ISO_INSTANT.format(Instant.now()) + ": " + message);
+    }
+}


### PR DESCRIPTION
### What this does

Makes the jar executable, so we can add debugging commands like `network-test`, which fetches some data from an arbitrary url:

```
% java -jar build/libs/snyk-java-runtime-agent.jar network-test https://hello.fau.xxx/
2019-07-18T07:26:47.490Z: Connection test
2019-07-18T07:26:47.491Z: Testing connection to: https://hello.fau.xxx/
2019-07-18T07:26:47.491Z: Protocol: https
2019-07-18T07:26:47.566Z: Connection ready.
2019-07-18T07:26:47.669Z: Connection initiated.
2019-07-18T07:26:47.682Z: Response code: 200
2019-07-18T07:26:47.682Z: Attempting to read.
2019-07-18T07:26:47.683Z: Response prefix: Hello, world!
2019-07-18T07:26:47.684Z: Complete.
```