### PR TITLE
chore: codeowners -> runtime

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @snyk/runtime


### PR DESCRIPTION
### What this does

Mark codeowners as Runtime.