### PR TITLE
feat: throw exception if projectId is empty string

### DIFF
--- a/src/main/java/io/snyk/agent/logic/Config.java
+++ b/src/main/java/io/snyk/agent/logic/Config.java
@@ -51,7 +51,7 @@ public class Config {
            boolean skipBuiltInRules,
            boolean skipMetaPosts,
            boolean addShutdownHook) {
-        if (null == projectId) {
+        if (null == projectId || projectId.trim().equals("")) {
             throw new IllegalStateException("projectId is required");
         }
         this.projectId = projectId;


### PR DESCRIPTION
- [ ] Tests written [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Throw exception if projectId is an empty string